### PR TITLE
handle error

### DIFF
--- a/client.js
+++ b/client.js
@@ -73,3 +73,9 @@ socket.on("close", function() {
   console.clear();
   process.exit(0);
 });
+
+
+socket.on('error', (err) => {
+  console.log('Could not connect to Redis at 127.0.0.1:6379: Connection refused')
+  process.exit(0)
+})


### PR DESCRIPTION
socket throws error when it can't connect to redis server. this patch handles error and prints msg to screen. I don't feel too strongly about the wording of the message.Let me know if you would like me to change it.